### PR TITLE
Bump EnricoMi/publish-unit-test-result-action from 2.1.0 to 2.11.0

### DIFF
--- a/bump_enricomi_publish_unit_test_result_action_from_2_1_0_to_2_11_0.txt
+++ b/bump_enricomi_publish_unit_test_result_action_from_2_1_0_to_2_11_0.txt
@@ -1,0 +1,1 @@
+Title: Bump EnricoMi/publish-unit-test-result-action from 2.1.0 to 2.11.0


### PR DESCRIPTION
Bump EnricoMi/publish-unit-test-result-action from 2.1.0 to 2.11.0

Bumps [EnricoMi/publish-unit-test-result-action](https://github.com/enricomi/publish-unit-test-result-action) from 2.1.0 to 2.11.0.
- [Release notes](https://github.com/enricomi/publish-unit-test-result-action/releases)
- [Commits](https://github.com/enricomi/publish-unit-test-result-action/compare/713caf1dd6f1c273144546ed2d79ca24a01f4623...ca89ad036b5fcd524c1017287fb01b5139908408)

---
updated-dependencies:
- dependency-name: EnricoMi/publish-unit-test-result-action
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

**Stack**:
- #1776 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
